### PR TITLE
Use Montserrat fonts in certain sections

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -132,9 +132,9 @@
 }
 
 .concept-text {
-  font-family: "Borel", sans-serif;
+  font-family: "Montserrat", sans-serif;
   font-size: 2.4rem;
-  line-height: 4rem;
+  line-height: 1.8;
   font-weight: 700;
   color: #555;
 }
@@ -189,9 +189,9 @@
 }
 
 .details-text-box {
-  font-family: "Borel", sans-serif;
+  font-family: "Montserrat", sans-serif;
   padding: 1.2rem;
-  line-height: 4rem;
+  line-height: 1.8;
 }
 
 .details-heading {
@@ -278,7 +278,7 @@
 }
 
 .restaurant-header {
-  font-family: "Borel", sans-serif;
+  font-family: "Montserrat", sans-serif;
   color: #fff;
   margin-bottom: 1.6rem;
   text-align: center;

--- a/index.html
+++ b/index.html
@@ -88,8 +88,6 @@
             <p class="concept-text">
               Viens composer ta <span>cocotte</span> et te régaler chez
               <span>Meurette</span>.
-              <br />
-              <br />
               Compose ta <span>cocotte</span> à partir de nos bons
               <span>plats mijotés</span>: cordons bleus au comté, saucisse
               purée, poulet moutarde et bien d’autres petits plats.
@@ -112,8 +110,7 @@
           <div class="concept-text-box">
             <p class="concept-text">
               Quel que soit ton choix, c’est promis tu auras l’impression de
-              déjeuner <span>chez Mamie</span>. <br />
-              <br />
+              déjeuner <span>chez Mamie</span>.
               <span>PS</span> : les plats changent souvent alors hésite pas à
               regarder notre menu et à nous suivre sur Insta pour connaître la
               carte de la semaine &MediumSpace;<span>;)</span>


### PR DESCRIPTION
## Summary
- switch concept text, details text, and restaurant headers to Montserrat
- keep Borel only for specific headings
- remove Borel-specific `<br />` line spacing in concept text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879174514108323bba080d91a6e5d66