### PR TITLE
Add radial fade around concept images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -149,6 +149,10 @@
 
 .concept-img {
   height: 32rem;
+  -webkit-mask-image: radial-gradient(circle, rgba(0, 0, 0, 1) 70%, rgba(0, 0, 0, 0) 100%);
+  mask-image: radial-gradient(circle, rgba(0, 0, 0, 1) 70%, rgba(0, 0, 0, 0) 100%);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
 }
 
 /***********************/


### PR DESCRIPTION
## Summary
- add radial mask to the concept images so they fade into the section background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687922e5591c83239a3b8fcd743720bb