### PR TITLE
Add CMS fields for menu and content

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -21,3 +21,23 @@ collections:
           - label: "Toppings"
             name: "toppings"
             widget: list
+          - label: "Nom du menu"
+            name: "menu_name"
+            widget: string
+  - name: "contenu"
+    label: "Contenu"
+    files:
+      - label: "Contenu du site"
+        name: "content"
+        file: "data/content.json"
+        format: "json"
+        fields:
+          - label: "Image 1 - Section concept"
+            name: "concept_img1"
+            widget: image
+          - label: "Image 2 - Section concept"
+            name: "concept_img2"
+            widget: image
+          - label: "Message de recrutement"
+            name: "cta_text"
+            widget: text

--- a/data/content.json
+++ b/data/content.json
@@ -1,0 +1,5 @@
+{
+  "concept_img1": "img/images/food-zenital/concept_plat_bis_1.jpg",
+  "concept_img2": "img/images/food-zenital/concept_plat_bis_2.jpg",
+  "cta_text": "Si tu veux rejoindre un de nos restaurants pour nous aider à préparer de bons petits plats, c'est ici que ça se passe."
+}

--- a/data/menu.json
+++ b/data/menu.json
@@ -18,5 +18,6 @@
     "Oignons frits",
     "Champignons sautés",
     "Croûtons"
-  ]
+  ],
+  "menu_name": "Menu"
 }

--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
           <div class="concept-img-box">
             <img
               class="concept-img"
+              id="concept-img-1"
               alt="Vue zénitale d'une cocotte garnie d'un plat mijoté"
               src="img/images/food-zenital/concept_plat_bis_1.jpg"
             />
@@ -129,6 +130,7 @@
           <div class="concept-img-box">
             <img
               class="concept-img"
+              id="concept-img-2"
               alt="Autre prise de vue d'une cocotte remplie d'un plat traditionnel"
               src="img/images/food-zenital/concept_plat_bis_2.jpg"
             />
@@ -149,7 +151,7 @@
 
       <section class="section-menu" id="menu">
         <div class="container">
-          <span class="subheading">Menu</span>
+          <span class="subheading" id="menu-name">Menu</span>
           <h2 class="heading-secondary">Compose ta cocotte !</h2>
         </div>
         <div class="container grid grid--center-v grid--menu">
@@ -224,7 +226,7 @@
           <div class="cta">
             <div class="cta-text-box">
               <h2 class="heading-secondary">Rejoins l'équipe !</h2>
-              <p class="cta-text">
+              <p class="cta-text" id="cta-text">
                 Si tu veux rejoindre un de nos restaurants pour nous aider à
                 préparer de bons petits plats, c'est ici que ça se passe.
               </p>
@@ -296,6 +298,7 @@
       </div>
     </footer>
     <script defer src="js/load-menu.js"></script>
+    <script defer src="js/load-content.js"></script>
     <script defer src="js/script.js"></script>
     <script
       type="module"

--- a/js/load-content.js
+++ b/js/load-content.js
@@ -1,0 +1,19 @@
+fetch('data/content.json')
+  .then(response => response.json())
+  .then(data => {
+    const img1 = document.getElementById('concept-img-1');
+    const img2 = document.getElementById('concept-img-2');
+    if (img1 && data.concept_img1) {
+      img1.src = data.concept_img1;
+    }
+    if (img2 && data.concept_img2) {
+      img2.src = data.concept_img2;
+    }
+    const ctaTextEl = document.getElementById('cta-text');
+    if (ctaTextEl && data.cta_text) {
+      ctaTextEl.textContent = data.cta_text;
+    }
+  })
+  .catch(err => {
+    console.error('Error loading content', err);
+  });

--- a/js/load-menu.js
+++ b/js/load-menu.js
@@ -4,6 +4,7 @@ fetch('data/menu.json')
     const platList = document.getElementById('plat-list');
     const accList = document.getElementById('accompagnement-list');
     const topList = document.getElementById('topping-list');
+    const menuNameEl = document.getElementById('menu-name');
     if (platList) {
       platList.innerHTML = '';
       data.plats.forEach(item => {
@@ -27,6 +28,9 @@ fetch('data/menu.json')
         li.textContent = item;
         topList.appendChild(li);
       });
+    }
+    if (menuNameEl && data.menu_name) {
+      menuNameEl.textContent = data.menu_name;
     }
   })
   .catch(err => {


### PR DESCRIPTION
## Summary
- extend Netlify CMS menu collection with a menu name
- create a new `contenu` collection for concept images and CTA message
- add data files for content
- load new data on the page through small JS helpers
- update HTML to allow dynamic content replacement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fd3954dfc8323b8eba1d50cbd845c